### PR TITLE
fix(build): make sure that the current version is used during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .aider*
 .opencode*
 OpenCode.md
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w
+      - -s -w -X github.com/mark3labs/mcp-filesystem-server/filesystemserver.Version={{.Version}}
     binary: mcp-filesystem-server
     main: .
 
@@ -40,7 +40,7 @@ checksum:
 
 # Using new snapshot configuration
 snapshot:
-  name_template: "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}"
+  version_template: "{{ .Version }}-SNAPSHOT-{{ .ShortCommit }}"
 
 changelog:
   sort: asc

--- a/filesystemserver/server.go
+++ b/filesystemserver/server.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-var Version = "0.4.1"
+var Version = "dev"
 
 func NewFilesystemServer(allowedDirs []string) (*server.MCPServer, error) {
 


### PR DESCRIPTION
I noticed that the `Version` was not set during the build. This change will fix it.

I changed the default value to `dev` to avoid confusion. There is one downside as users importing this package and using it with the `in-process` client will always see `dev` as the version, but IMO this is less problematic than showing an outdated version