### PR TITLE
Fix inaccurate file time metadata using cross-platform timestamp retrieval

### DIFF
--- a/filesystemserver/handler.go
+++ b/filesystemserver/handler.go
@@ -9,13 +9,14 @@ import (
 	"mime"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/djherbis/times"
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/gobwas/glob"
 	"github.com/mark3labs/mcp-go/mcp"
-	"slices"
 )
 
 const (
@@ -238,11 +239,13 @@ func (fs *FilesystemHandler) getFileStats(path string) (FileInfo, error) {
 		return FileInfo{}, err
 	}
 
+	timespec := times.Get(info)
+
 	return FileInfo{
 		Size:        info.Size(),
-		Created:     info.ModTime(), // Note: ModTime used as birth time isn't always available
-		Modified:    info.ModTime(),
-		Accessed:    info.ModTime(), // Note: Access time isn't always available
+		Created:     timespec.BirthTime(),
+		Modified:    timespec.ModTime(),
+		Accessed:    timespec.AccessTime(),
 		IsDirectory: info.IsDir(),
 		IsFile:      !info.IsDir(),
 		Permissions: fmt.Sprintf("%o", info.Mode().Perm()),

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mark3labs/mcp-filesystem-server
 go 1.23.2
 
 require (
+	github.com/djherbis/times v1.6.0
 	github.com/gabriel-vasile/mimetype v1.4.9
 	github.com/gobwas/glob v0.2.3
 	github.com/mark3labs/mcp-go v0.31.0
@@ -16,5 +17,6 @@ require (
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/net v0.39.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
+github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
@@ -28,6 +30,9 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
 golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
updating the logic for retrieving file timestamps to correctly reflect creation, modification, and access times from the underlying file system

It uses a cross-platform filesystem time library to fetch the actual timestamps, improving accuracy and consistency across platforms.

Fixes #37