### PR TITLE
feat: add modify_file and search_within_files tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ This MCP server provides secure access to the local filesystem via the Model Con
   - Delete a file or directory from the file system
   - Parameters: `path` (required): Path to the file or directory to delete, `recursive` (optional): Whether to recursively delete directories (default: false)
 
+- **modify_file**
+  - Update file by finding and replacing text using string matching or regex
+  - Parameters: `path` (required): Path to the file to modify, `find` (required): Text to search for, `replace` (required): Text to replace with, `all_occurrences` (optional): Replace all occurrences (default: true), `regex` (optional): Treat find pattern as regex (default: false)
+
 #### Directory Operations
 
 - **list_directory**
@@ -51,6 +55,10 @@ This MCP server provides secure access to the local filesystem via the Model Con
 - **search_files**
   - Recursively search for files and directories matching a pattern
   - Parameters: `path` (required): Starting path for the search, `pattern` (required): Search pattern to match against file names
+
+- **search_within_files**
+  - Search for text within file contents across directory trees
+  - Parameters: `path` (required): Starting directory for the search, `substring` (required): Text to search for within file contents, `depth` (optional): Maximum directory depth to search, `max_results` (optional): Maximum number of results to return (default: 1000)
 
 - **get_file_info**
   - Retrieve detailed metadata about a file or directory

--- a/filesystemserver/server.go
+++ b/filesystemserver/server.go
@@ -158,5 +158,47 @@ func NewFilesystemServer(allowedDirs []string) (*server.MCPServer, error) {
 		),
 	), h.handleDeleteFile)
 
+	s.AddTool(mcp.NewTool(
+		"modify_file",
+		mcp.WithDescription("Update file by finding and replacing text. Provides a simple pattern matching interface without needing exact character positions."),
+		mcp.WithString("path",
+			mcp.Description("Path to the file to modify"),
+			mcp.Required(),
+		),
+		mcp.WithString("find",
+			mcp.Description("Text to search for (exact match or regex pattern)"),
+			mcp.Required(),
+		),
+		mcp.WithString("replace",
+			mcp.Description("Text to replace with"),
+			mcp.Required(),
+		),
+		mcp.WithBoolean("all_occurrences",
+			mcp.Description("Replace all occurrences of the matching text (default: true)"),
+		),
+		mcp.WithBoolean("regex",
+			mcp.Description("Treat the find pattern as a regular expression (default: false)"),
+		),
+	), h.handleModifyFile)
+
+	s.AddTool(mcp.NewTool(
+		"search_within_files",
+		mcp.WithDescription("Search for text within file contents. Unlike search_files which only searches file names, this tool scans the actual contents of text files for matching substrings. Binary files are automatically excluded from the search. Reports file paths and line numbers where matches are found."),
+		mcp.WithString("path",
+			mcp.Description("Starting path for the search (must be a directory)"),
+			mcp.Required(),
+		),
+		mcp.WithString("substring",
+			mcp.Description("Text to search for within file contents"),
+			mcp.Required(),
+		),
+		mcp.WithNumber("depth",
+			mcp.Description("Maximum directory depth to search (default: unlimited)"),
+		),
+		mcp.WithNumber("max_results",
+			mcp.Description("Maximum number of results to return (default: 1000)"),
+		),
+	), h.handleSearchWithinFiles)
+
 	return s, nil
 }


### PR DESCRIPTION
Adds two file manipulation tools to the filesystem server:

### modify_file
- Find and replace text in files using string matching or regex
- Supports single or multiple occurrences replacement
- Returns modification count and file metadata

### search_within_files  
- Search for text within file contents across directory trees
- Configurable depth limits and result caps
- Excludes binary files, reports line numbers and context
- Distinct from existing `search_files` which only searches filenames
