### PR TITLE
fix: panic on retrieving creation time in getFileStats

### DIFF
--- a/filesystemserver/handler.go
+++ b/filesystemserver/handler.go
@@ -253,11 +253,19 @@ func (fs *FilesystemHandler) getFileStats(path string) (FileInfo, error) {
 		return FileInfo{}, err
 	}
 
-	timespec := times.Get(info)
+	timespec, err := times.Stat(path)
+	if err != nil {
+		return FileInfo{}, fmt.Errorf("failed to get file times: %w", err)
+	}
+
+	createdTime := time.Time{}
+	if timespec.HasBirthTime() {
+		createdTime = timespec.BirthTime()
+	}
 
 	return FileInfo{
 		Size:        info.Size(),
-		Created:     timespec.BirthTime(),
+		Created:     createdTime,
 		Modified:    timespec.ModTime(),
 		Accessed:    timespec.AccessTime(),
 		IsDirectory: info.IsDir(),


### PR DESCRIPTION
It fixes two subtle issues when retrieving file created time (btime):

- Use `times.Stat` instead of `times.Get`:
`times.Get` doesn’t return `btime` on linux platforms, as noted:
> Get(FileInfo) never returns btime.

- Avoid panic when `btime` is unavailable:
We need to check `HasBirthTime()` before calling `BirthTime()`, to prevent `panic`:
```go
func (nobtime) BirthTime() time.Time { panic("birthtime not available") }
```