### PR TITLE
fix: correct license copyright from Anthropic to Mark III Labs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Anthropic, PBC
+Copyright (c) 2024 Mark III Labs, LLC.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Fixes #45 by correcting the LICENSE file copyright holder from "Anthropic, PBC" to "Mark III Labs, LLC."
- This was likely a copy-paste error from the original Anthropic MCP filesystem server template

## Changes
- Updated LICENSE file line 3 to show the correct copyright holder

## Test plan
- [x] LICENSE file updated with correct copyright information
- [x] No code changes required, only license text correction