### PR TITLE
fix: path mismatches in tests on Windows and macOS

### DIFF
--- a/filesystemserver/handler/get_file_info_test.go
+++ b/filesystemserver/handler/get_file_info_test.go
@@ -43,8 +43,11 @@ func TestHandleGetFileInfo(t *testing.T) {
 		// Verify the response contains file information
 		require.Len(t, res.Content, 2)
 		textContent := res.Content[0].(mcp.TextContent)
+		resolvedFilePath, err := filepath.EvalSymlinks(filePath)
+		require.NoError(t, err)
+
 		assert.Contains(t, textContent.Text, "File information for:")
-		assert.Contains(t, textContent.Text, filePath)
+		assert.Contains(t, textContent.Text, resolvedFilePath)
 		assert.Contains(t, textContent.Text, "IsFile: true")
 		assert.Contains(t, textContent.Text, "IsDirectory: false")
 		assert.Contains(t, textContent.Text, "Size: 13 bytes") // Length of "Hello, world!"
@@ -70,8 +73,11 @@ func TestHandleGetFileInfo(t *testing.T) {
 		// Verify the response contains directory information
 		require.Len(t, res.Content, 2)
 		textContent := res.Content[0].(mcp.TextContent)
+		resolvedDirPath, err := filepath.EvalSymlinks(dirPath)
+		require.NoError(t, err)
+
 		assert.Contains(t, textContent.Text, "File information for:")
-		assert.Contains(t, textContent.Text, dirPath)
+		assert.Contains(t, textContent.Text, resolvedDirPath)
 		assert.Contains(t, textContent.Text, "IsFile: false")
 		assert.Contains(t, textContent.Text, "IsDirectory: true")
 		assert.Contains(t, textContent.Text, "MIME Type: directory")

--- a/filesystemserver/handler/handler_test.go
+++ b/filesystemserver/handler/handler_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// resolveAllowedDirs generates a list of allowed paths, including their resolved symlinks.
-// This ensures both the original paths and their symlink-resolved counterparts are included,
-// which is useful when paths may be symlinks (e.g., t.TempDir() on some Unix systems).
+// resolveAllowedDirs generates a list of allowed paths, including their resolved counterparts.
+// This ensures both the original paths and their resolved versions are included,
+// which handles path normalization across platforms (symlinks on Unix, 8.3 short names on Windows).
 func resolveAllowedDirs(t *testing.T, dirs ...string) []string {
 	t.Helper()
 	allowedDirs := make([]string, 0)

--- a/filesystemserver/handler/list_directory_test.go
+++ b/filesystemserver/handler/list_directory_test.go
@@ -47,8 +47,11 @@ func TestHandleListDirectory(t *testing.T) {
 		// Verify the response contains directory listing
 		require.Len(t, res.Content, 2)
 		textContent := res.Content[0].(mcp.TextContent)
+		resolvedTmpDir, err := filepath.EvalSymlinks(tmpDir)
+		require.NoError(t, err)
+
 		assert.Contains(t, textContent.Text, "Directory listing for:")
-		assert.Contains(t, textContent.Text, tmpDir)
+		assert.Contains(t, textContent.Text, resolvedTmpDir)
 		assert.Contains(t, textContent.Text, "[DIR]  subdirectory")
 		assert.Contains(t, textContent.Text, "[FILE] test_file.txt")
 		assert.Contains(t, textContent.Text, "11 bytes") // Length of "hello world"
@@ -79,8 +82,11 @@ func TestHandleListDirectory(t *testing.T) {
 		// Verify the response contains directory listing for empty directory
 		require.Len(t, res.Content, 2)
 		textContent := res.Content[0].(mcp.TextContent)
+		resolvedEmptyDir, err := filepath.EvalSymlinks(emptyDir)
+		require.NoError(t, err)
+
 		assert.Contains(t, textContent.Text, "Directory listing for:")
-		assert.Contains(t, textContent.Text, emptyDir)
+		assert.Contains(t, textContent.Text, resolvedEmptyDir)
 	})
 
 	t.Run("try to list a file instead of directory", func(t *testing.T) {

--- a/filesystemserver/handler/read_file_test.go
+++ b/filesystemserver/handler/read_file_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -46,8 +47,11 @@ func TestReadfile_Invalid(t *testing.T) {
 
 	result, err := handler.HandleReadFile(context.Background(), request)
 	require.NoError(t, err)
-	assert.True(t, result.IsError)
-	assert.Contains(t, fmt.Sprint(result.Content[0]), "no such file or directory")
+	require.True(t, result.IsError)
+
+	errorMsg := fmt.Sprint(result.Content[0])
+	assert.True(t,
+		strings.Contains(errorMsg, "no such file or directory") || strings.Contains(errorMsg, "system cannot find the file specified"))
 }
 
 func TestReadfile_NoAccess(t *testing.T) {

--- a/filesystemserver/handler/search_files_test.go
+++ b/filesystemserver/handler/search_files_test.go
@@ -69,8 +69,11 @@ func TestSearchFiles_Pattern(t *testing.T) {
 			assert.False(t, result.IsError)
 			assert.Len(t, result.Content, 1)
 
+			resultText := result.Content[0].(mcp.TextContent).Text
 			for _, match := range test.matches {
-				assert.Contains(t, result.Content[0].(mcp.TextContent).Text, match)
+				resolvedMatch, err := filepath.EvalSymlinks(match)
+				require.NoError(t, err)
+				assert.Contains(t, resultText, resolvedMatch)
 			}
 		})
 	}


### PR DESCRIPTION
### Problem
Tests were failing on Windows but passing on macOS and Linux due to differences in how paths are resolved.

### Root Cause
- **Windows**: `t.TempDir()` returns 8.3 short names (e.g., `RUNNER~1`) in GitHub Actions, while `filepath.EvalSymlinks()` resolves these to long names (e.g., `runneradmin`). This mismatch caused assertions to fail.
- **macOS**: Symlink resolution changes paths consistently (e.g., `/var/folders` resolving to `/private/var/folders`), but still preserves substring relationships, so the tests passed (the checks are false negative)
- **Linux**: No path changes, tests work as expected

### Solution
Normalize all expected paths in the tests by applying `filepath.EvalSymlinks()` before assertions. This ensures consistent behavior across all platforms: on Windows, it resolves 8.3 short names to their long form, and on macOS, it resolves symlinks to their canonical paths.
