### PR TITLE
ci: update test workflow to run on multiple OS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,10 @@ on: [push]
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -18,4 +21,4 @@ jobs:
           check-latest: true
 
       - name: Run tests
-        run: go test ./...
+        run: go test -race ./...


### PR DESCRIPTION
It expands the CI test workflow to run unit tests on `macOS` and `Windows` in addition to `Linux`. This ensures the MCP Filesystem Server works correctly across all major operating systems, as filesystem operations can behave differently between platforms due to varying path separators, file permissions, and symlink handling.